### PR TITLE
[error fix] Dropzone already attached

### DIFF
--- a/dropzone.svelte
+++ b/dropzone.svelte
@@ -21,7 +21,7 @@
       ...options
     });
     if (autoDiscover !== true) {
-      svDropzone.autoDiscover = false;
+      Dropzone.autoDiscover = false;
     }
 
     svDropzone.on("addedfile", f => {


### PR DESCRIPTION
Dropzone ain't exactly OOP written. It checks autoDiscover during load, not instance creation.